### PR TITLE
feat: emitFile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ This option determines the name of non-entry chunk files.
 
 Works like [`output.chunkFilename`](https://webpack.js.org/configuration/output/#outputchunkfilename)
 
+#### `emitFile`
+
+Type: `Boolean`
+Default: `true`
+
+If true, emits a file (writes a file to the filesystem). If false, the plugin
+will extract the CSS but **will not** emit the file. It is often useful to
+disable this option for server-side packages.
+
 #### `ignoreOrder`
 
 Type: `Boolean`

--- a/src/index.js
+++ b/src/index.js
@@ -309,7 +309,7 @@ class MiniCssExtractPlugin {
     this._sortedModulesCache = new WeakMap();
 
     this.options = Object.assign(
-      { filename: DEFAULT_FILENAME, ignoreOrder: false },
+      { filename: DEFAULT_FILENAME, ignoreOrder: false, emitFile: true },
       options
     );
 
@@ -426,6 +426,7 @@ class MiniCssExtractPlugin {
         new CssDependencyTemplate()
       );
 
+      const { emitFile } = this.options;
       if (isWebpack4) {
         compilation.mainTemplate.hooks.renderManifest.tap(
           pluginName,
@@ -439,7 +440,7 @@ class MiniCssExtractPlugin {
             const filenameTemplate =
               chunk.filenameTemplate || this.options.filename;
 
-            if (renderedModules.length > 0) {
+            if (renderedModules.length > 0 && emitFile) {
               result.push({
                 render: () =>
                   this.renderContentAsset(
@@ -473,7 +474,7 @@ class MiniCssExtractPlugin {
             const filenameTemplate =
               chunk.filenameTemplate || this.options.chunkFilename;
 
-            if (renderedModules.length > 0) {
+            if (renderedModules.length > 0 && emitFile) {
               result.push({
                 render: () =>
                   this.renderContentAsset(
@@ -515,7 +516,7 @@ class MiniCssExtractPlugin {
               ? this.options.filename
               : this.options.chunkFilename;
 
-            if (renderedModules.length > 0) {
+            if (renderedModules.length > 0 && emitFile) {
               result.push({
                 render: () =>
                   this.renderContentAsset(

--- a/src/plugin-options.json
+++ b/src/plugin-options.json
@@ -22,6 +22,10 @@
         }
       ]
     },
+    "emitFile": {
+      "description": "If true, emits a file (writes a file to the filesystem). If false, the plugin will extract the CSS but will not emit the file. It is often useful to disable this option for server-side packages. (https://github.com/webpack-contrib/mini-css-extract-plugin#emitFile).",
+      "type": "boolean"
+    },
     "ignoreOrder": {
       "type": "boolean"
     },

--- a/test/__snapshots__/validate-plugin-options.test.js.snap
+++ b/test/__snapshots__/validate-plugin-options.test.js.snap
@@ -16,6 +16,12 @@ exports[`validate options should throw an error on the "chunkFilename" option wi
     * options.chunkFilename should be an instance of function."
 `;
 
+exports[`validate options should throw an error on the "emitFile" option with "1" value 1`] = `
+"Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
+ - options.emitFile should be a boolean.
+   -> If true, emits a file (writes a file to the filesystem). If false, the plugin will extract the CSS but will not emit the file. It is often useful to disable this option for server-side packages. (https://github.com/webpack-contrib/mini-css-extract-plugin#emitFile)."
+`;
+
 exports[`validate options should throw an error on the "filename" option with "true" value 1`] = `
 "Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
  - options.filename should be one of these:
@@ -99,47 +105,47 @@ exports[`validate options should throw an error on the "linkType" option with "i
 exports[`validate options should throw an error on the "unknown" option with "/test/" value 1`] = `
 "Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { filename?, chunkFilename?, ignoreOrder?, insert?, attributes?, linkType? }"
+   object { filename?, chunkFilename?, emitFile?, ignoreOrder?, insert?, attributes?, linkType? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "[]" value 1`] = `
 "Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { filename?, chunkFilename?, ignoreOrder?, insert?, attributes?, linkType? }"
+   object { filename?, chunkFilename?, emitFile?, ignoreOrder?, insert?, attributes?, linkType? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "{"foo":"bar"}" value 1`] = `
 "Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { filename?, chunkFilename?, ignoreOrder?, insert?, attributes?, linkType? }"
+   object { filename?, chunkFilename?, emitFile?, ignoreOrder?, insert?, attributes?, linkType? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "{}" value 1`] = `
 "Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { filename?, chunkFilename?, ignoreOrder?, insert?, attributes?, linkType? }"
+   object { filename?, chunkFilename?, emitFile?, ignoreOrder?, insert?, attributes?, linkType? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "1" value 1`] = `
 "Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { filename?, chunkFilename?, ignoreOrder?, insert?, attributes?, linkType? }"
+   object { filename?, chunkFilename?, emitFile?, ignoreOrder?, insert?, attributes?, linkType? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "false" value 1`] = `
 "Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { filename?, chunkFilename?, ignoreOrder?, insert?, attributes?, linkType? }"
+   object { filename?, chunkFilename?, emitFile?, ignoreOrder?, insert?, attributes?, linkType? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "test" value 1`] = `
 "Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { filename?, chunkFilename?, ignoreOrder?, insert?, attributes?, linkType? }"
+   object { filename?, chunkFilename?, emitFile?, ignoreOrder?, insert?, attributes?, linkType? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "true" value 1`] = `
 "Invalid options object. Mini CSS Extract Plugin has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object { filename?, chunkFilename?, ignoreOrder?, insert?, attributes?, linkType? }"
+   object { filename?, chunkFilename?, emitFile?, ignoreOrder?, insert?, attributes?, linkType? }"
 `;

--- a/test/validate-plugin-options.test.js
+++ b/test/validate-plugin-options.test.js
@@ -20,6 +20,10 @@ describe('validate options', () => {
       ],
       failure: [true],
     },
+    emitFile: {
+      success: [true, false],
+      failure: [1],
+    },
     ignoreOrder: {
       success: [true, false],
       failure: [1],


### PR DESCRIPTION
Add emitFile option (default: true).

 * If true, emits a file (writes a file to the filesystem).
 * If false, the plugin will extract the CSS but will not emit the file.

It is often useful to disable this option for server-side packages.